### PR TITLE
new image for extra_pip_packages fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhodium/worker:19f9969fa333efc87445d5d6deea0096d7d23d81
+FROM rhodium/worker:ece12fd625eafef8d17329a080af807f265a399f
 
 USER root
 


### PR DESCRIPTION
New image incorporates RhodiumGroup/docker_images#46, which includes a patch for installing EXTRA_PIP_PACKAGES