### PR TITLE
update base image to v0.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhodium/worker:v0.2.1
+FROM rhodium/worker:v0.2.2
 
 USER root
 


### PR DESCRIPTION
includes rhg-compute-tools and google-cloud-sdk.

Authenticate google cloud sdk on startup by providing the service account credentials file path to `GCLOUD_DEFAULT_TOKEN_FILE`, e.g. with:

    env.append({'name': 'GCLOUD_DEFAULT_TOKEN_FILE', 'value': '/opt/gcsfuse_tokens/rhg-data.json'})