### PR TITLE
update worker image to v0.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhodium/worker:v0.2.3
+FROM rhodium/worker:dev
 
 ## install Clawpack
 ENV CLAW=/clawpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhodium/worker:dev
+FROM rhodium/worker:v0.2.4
 
 ## install Clawpack
 ENV CLAW=/clawpack


### PR DESCRIPTION
Includes a number of package upgrades, most notably to jupyterlab and dask.distributed.

@bolliger32 The worker+notebook pair will probably be broken by the notebook upgrade, so this worker-side upgrade is likely critical. Let me know if it anything goes wrong and we can roll back the cluster.